### PR TITLE
fix: add version to markupsafe to avoid failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Jinja2==2.11.3
+markupsafe==2.0.1


### PR DESCRIPTION
Markupsafe latest version no longer features "soft_unicode" and so this script fails in default state